### PR TITLE
fix: avoid unnecessary Vec allocation when checking 5th field

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -106,7 +106,7 @@ where
     let mut seen: AHashSet<String> = AHashSet::new();
 
     while reader.read_record(&mut carry)? {
-        if carry.iter().collect::<Vec<&str>>()[5].is_empty() {
+        if carry.get(5).map_or(true, |f| f.is_empty()) {
             continue; // If the 5th field is empty, it's a record we need to avoid deserializing.
         }
 


### PR DESCRIPTION
## Summary

- Replace `.iter().collect::<Vec<&str>>()[5]` with `StringRecord::get(5)` to avoid a heap allocation on every input record.
- `get()` is O(1) and returns `Option<&str>`, so we also gracefully handle records with fewer than 6 fields.

## Test plan

- [x] All existing unit and integration tests pass