### PR TITLE
fix: ensure we can build on linux-aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ csv = "1.4.0"
 env_logger = "0.11.8"
 log = "0.4.28"
 proglog = "0.4.0"
-rust-htslib = "0.51.0"
+rust-htslib = "0.46.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_with = { version = "3.15.0" }
 structopt = "0.3.26"


### PR DESCRIPTION
Recently, `linux-aarch64` has changed such that this project no longer builds there. The issue is a bindgen and opaque type issue. It must be solved at the rust-htslib level. Luckily, 0.46 shouldn't have this issue and seems to work just as fine. Only testing this with Bioconda after release will prove it actually works.

Upstream issue:

- https://github.com/rust-bio/rust-htslib/issues/434